### PR TITLE
Convert PosixPath to str before passing to cfgrib

### DIFF
--- a/herbie/archive.py
+++ b/herbie/archive.py
@@ -898,7 +898,7 @@ class Herbie:
         # Use cfgrib.open_datasets, just in case there are multiple "hypercubes"
         # for what we requested.
         Hxr = cfgrib.open_datasets(
-            self.get_localFilePath(searchString=searchString),
+            str(self.get_localFilePath(searchString=searchString)),
             backend_kwargs=backend_kwargs,
         )
 


### PR DESCRIPTION
I was just following the basic setup guide. Installed with `conda` using the example `environment.yaml` file, and ran into this issue:
```
>>> H.xarray('TMP:2 m')
indexpath value  is ignored
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/herbie/archive.py", line 900, in xarray
    Hxr = cfgrib.open_datasets(
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_store.py", line 105, in open_datasets
    datasets = open_variable_datasets(path, backend_kwargs=backend_kwargs, **kwargs)
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_store.py", line 93, in open_variable_datasets
    datasets.extend(raw_open_datasets(path, bk, **kwargs))
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_store.py", line 66, in raw_open_datasets
    datasets.append(open_dataset(path, backend_kwargs=backend_kwargs, **kwargs))
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_store.py", line 39, in open_dataset
    return xr.open_dataset(path, **kwargs)  # type: ignore
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/xarray/backends/api.py", line 495, in open_dataset
    backend_ds = backend.open_dataset(
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_plugin.py", line 99, in open_dataset
    store = CfGribDataStore(
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/xarray_plugin.py", line 39, in __init__
    self.ds = opener(filename, **backend_kwargs)
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/dataset.py", line 728, in open_fieldset
    index = messages.FieldsetIndex.from_fieldset(fieldset, index_keys, computed_keys)
  File "/usr/local/anaconda3/envs/herbie/lib/python3.9/site-packages/cfgrib/messages.py", line 365, in from_fieldset
    iteritems = enumerate(fieldset)
TypeError: 'PosixPath' object is not iterable
```

It seems like that cfgrib either expects a `str` filename, or an already opened object: https://github.com/ecmwf/cfgrib/blob/a0d9763/cfgrib/xarray_plugin.py#L35-L38

Converting the path to `str` here makes the example pass for me.